### PR TITLE
[OX 퀴즈 API] Random OX 퀴즈 제공 기능 구현

### DIFF
--- a/src/main/java/com/example/sumda/controller/QuizController.java
+++ b/src/main/java/com/example/sumda/controller/QuizController.java
@@ -1,0 +1,21 @@
+package com.example.sumda.controller;
+
+import com.example.sumda.entity.Quiz;
+import com.example.sumda.service.QuizService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/oxgames")
+public class QuizController {
+
+    @Autowired
+    private QuizService quizService;
+
+    @GetMapping
+    public Quiz getRandomQuiz() {
+        return quizService.getRandomQuiz();
+    }
+}

--- a/src/main/java/com/example/sumda/entity/Quiz.java
+++ b/src/main/java/com/example/sumda/entity/Quiz.java
@@ -1,0 +1,29 @@
+package com.example.sumda.entity;
+
+import jakarta.persistence.Entity;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "quizzes")
+@Getter
+@Setter
+@NoArgsConstructor
+public class Quiz {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String question;
+
+    @Column(nullable = false, length = 1)
+    private String answer;
+
+    @Column(nullable = false)
+    private String explanation;
+}

--- a/src/main/java/com/example/sumda/repository/QuizRepository.java
+++ b/src/main/java/com/example/sumda/repository/QuizRepository.java
@@ -1,0 +1,9 @@
+package com.example.sumda.repository;
+
+import com.example.sumda.entity.Quiz;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface QuizRepository extends JpaRepository<Quiz, Long> {
+}

--- a/src/main/java/com/example/sumda/service/QuizService.java
+++ b/src/main/java/com/example/sumda/service/QuizService.java
@@ -1,0 +1,25 @@
+package com.example.sumda.service;
+
+import com.example.sumda.entity.Quiz;
+import com.example.sumda.repository.QuizRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Random;
+
+@Service
+public class QuizService {
+
+    @Autowired
+    private QuizRepository quizRepository;
+
+    public Quiz getRandomQuiz() {
+        List<Quiz> quizzes = quizRepository.findAll();
+        if (quizzes.isEmpty()) {
+            throw new RuntimeException("퀴즈 데이터가 없습니다.");
+        }
+        Random random = new Random();
+        return quizzes.get(random.nextInt(quizzes.size()));
+    }
+}


### PR DESCRIPTION
## 1. 기능 개요

/api/oxgames 엔드포인트를 통해 OX 퀴즈 데이터를 랜덤으로 하나 반환하는 API를 구현했습니다.
데이터베이스에 저장된 퀴즈 데이터를 무작위로 선택하여 JSON 형식으로 클라이언트에 제공하도록 했습니다.

## 2. 구현 내용

### Entity 생성: quizzes 테이블과 매핑된 Quiz Entity 생성.
@Entity, @Table 어노테이션을 사용해 quizzes 테이블과 연결.
id, question, answer, explanation 필드 정의.
Lombok의 @Getter, @Setter, @NoArgsConstructor를 사용하여 boilerplate 코드를 줄임.

### Repository 인터페이스: QuizRepository 선언.
JPA의 기본 기능을 사용하기 위해 별도의 메소드 없이 JpaRepository<Quiz, Long>만 상속.

### Service 계층: QuizService에서 랜덤으로 하나의 퀴즈를 가져오는 메소드 구현.
데이터베이스에서 모든 퀴즈 데이터를 조회한 뒤, 무작위로 하나를 선택해 반환.
퀴즈 데이터가 없을 경우 예외 처리.

###  Controller 계층: /api/oxgames 엔드포인트에서 랜덤 퀴즈를 제공하는 GET 메소드 구현.
QuizService에서 받아온 퀴즈 데이터를 그대로 JSON 형식으로 클라이언트에 전달.

## 3. 코드 구조
### Entity (Quiz)
- id (Primary Key)
- question: 퀴즈 질문
- answer: "O" 또는 "X"로 저장되는 정답
- explanation: 정답에 대한 설명
### Repository (QuizRepository)
- JpaRepository를 상속받아 기본 CRUD 메소드 제공.
### Service (QuizService)
- getRandomQuiz(): 퀴즈 데이터 중 무작위로 하나의 퀴즈를 반환하는 메소드.

### Controller (QuizController)
- /api/oxgames 엔드포인트에 대한 GET 요청을 처리하고, 랜덤 퀴즈 데이터를 JSON으로 반환.